### PR TITLE
Fixed minor discrepancies between instructions/tests

### DIFF
--- a/Part1/01-data-to-rows.js
+++ b/Part1/01-data-to-rows.js
@@ -157,7 +157,7 @@ function personRow (person) {
 
 
 /**
- * Builds a valid HTML table (as a string) from an array of `Person` opjects.
+ * Builds a valid HTML table (as a string) from an array of `Person` objects.
  * Please do not generate a table header -- so, just create html of the form
  * <table><tr><td></td>....</tr></table>
  * 

--- a/Part2/02-dom-tricks.js
+++ b/Part2/02-dom-tricks.js
@@ -59,12 +59,12 @@ function evenBoxesText () {
 
 // Problem 2d: set the HTML content of odd-numbered boxes.
 /**
- * set the HTML content of the even boxes to "<div> I am an inner box</div>"
+ * set the HTML content of the odd boxes to "<div> I am an inner box</div>"
  * no need for any particular return value
  * @returns {} 
  */
 function oddBoxesHtml () {
-  // set the HTML content of the even boxes to "<div> I am an inner box</div>"
+  // set the HTML content of the odd boxes to "<div> I am an inner box</div>"
   return '';
 }
 

--- a/Part3/03-dom-data.js
+++ b/Part3/03-dom-data.js
@@ -13,7 +13,7 @@ function wikiUrl (name) {
 
 /**
  * given a name, this function should return, as a string, a valid link to a wiki page
- * of the form <a href='link url'>content</a>
+ * of the form <a href="link url">name</a>
  * the function `wikiURL` should make it easier to do this.
  * @param {string} name
  * @returns {} 

--- a/test/test.js
+++ b/test/test.js
@@ -157,9 +157,7 @@ describe('Part 1: From Data to Rows', function() {
   });
 
   it('peopleRows should return a full <table> with appropriate data', function() {
-    expect (dtr.peopleRows([dtr.biko, dtr.tambo]), 'Check your table code for differences').to.equal(`<table><tr><td>Steve Biko</td><td>1946</td><td>1977</td><td>SASO,Black Consciousness</td><td>The most potent weapon in the hands of the oppressor is the mind of the oppressed.</td></tr>
-<tr><td>Oliver Tambo</td><td>1917</td><td>1993</td><td>ANC</td><td>The fight for freedom must go on until it is won; until our country is free and happy and peaceful as part of the community of man, we cannot rest.</td></tr>
-</table>`) ;
+    expect (dtr.peopleRows([dtr.biko, dtr.tambo]), 'Check your table code for differences').to.equal(`<table><tr><td>Steve Biko</td><td>1946</td><td>1977</td><td>SASO,Black Consciousness</td><td>The most potent weapon in the hands of the oppressor is the mind of the oppressed.</td></tr><tr><td>Oliver Tambo</td><td>1917</td><td>1993</td><td>ANC</td><td>The fight for freedom must go on until it is won; until our country is free and happy and peaceful as part of the community of man, we cannot rest.</td></tr></table>`) ;
   });
 });
 


### PR DESCRIPTION
peopleRows: test no longer requires newlines between table rows
oddBoxesHtml: no more sneaky "even"s in the instructions
wikiLink: instructions now ask for double quotes around the URL rather than single quotes